### PR TITLE
Refactor search logic and update UI styling

### DIFF
--- a/client/components/home/FeatureGrid.tsx
+++ b/client/components/home/FeatureGrid.tsx
@@ -116,8 +116,8 @@ function FeatureCard({ feature }: FeatureCardProps) {
         onPointerEnter={(event) => handlePointerMove(event)}
         className={cn(
           "relative h-full overflow-hidden rounded-3xl border border-white/12 bg-gradient-to-br from-white/14 via-white/8 to-white/4 px-7 py-9 text-left",
-          "shadow-md shadow-brand-500/15 transition-[transform,box-shadow] duration-100 ease-out will-change-transform backdrop-blur-[18px]",
-          "hover:shadow-lg hover:shadow-brand-500/20",
+          "shadow-sm shadow-brand-500/10 transition-[transform,box-shadow] duration-100 ease-out will-change-transform backdrop-blur-[18px]",
+          "hover:shadow-md hover:shadow-brand-500/15",
           "dark:border-white/10 dark:from-white/8 dark:via-white/4 dark:to-white/10",
         )}
         style={

--- a/client/components/layout/Header.tsx
+++ b/client/components/layout/Header.tsx
@@ -32,13 +32,13 @@ export function Header() {
   return (
     <header className="sticky top-0 z-40 backdrop-blur supports-[backdrop-filter]:bg-background/70 border-b border-border">
       <div className="container mx-auto flex h-16 items-center justify-between">
-        <Link to="/" className="flex items-center gap-2 font-black text-xl">
+        <Link to="/" className="flex items-center gap-3 font-black text-2xl">
           <img
             src="https://i.ibb.co/KjddQYWn/osintleak-osintleak-osintleak-osintleak-osintleak-osintleak-osintleak-osintleak-osintleak-osintleak.png"
             alt="Osint Info logo"
-            className="h-8 w-8 rounded"
+            className="h-10 w-10 rounded-lg"
           />
-          Osint Info
+          <span className="leading-none">Osint Info</span>
         </Link>
 
         <nav className="hidden md:flex items-center gap-6">

--- a/client/lib/search.ts
+++ b/client/lib/search.ts
@@ -37,7 +37,9 @@ export type PerformSearchResult = {
   hasResults: boolean;
 };
 
-export async function performSearch(query: string): Promise<PerformSearchResult> {
+export async function performSearch(
+  query: string,
+): Promise<PerformSearchResult> {
   const trimmed = query.trim();
   if (!trimmed) {
     throw new Error("Search query cannot be empty.");

--- a/client/lib/search.ts
+++ b/client/lib/search.ts
@@ -1,0 +1,79 @@
+export type SearchResult = unknown;
+
+function detectHasResults(value: SearchResult): boolean {
+  if (Array.isArray(value)) {
+    return value.length > 0;
+  }
+  if (value && typeof value === "object") {
+    return Object.keys(value as Record<string, unknown>).length > 0;
+  }
+  if (typeof value === "string") {
+    return value.trim().length > 0 && !/no results/i.test(value);
+  }
+  return Boolean(value);
+}
+
+async function readResponseBody(response: Response): Promise<SearchResult> {
+  const contentType = response.headers.get("content-type") || "";
+  const raw = await response.text();
+
+  if (!raw) {
+    return contentType.includes("application/json") ? {} : "";
+  }
+
+  if (contentType.includes("application/json")) {
+    try {
+      return JSON.parse(raw) as SearchResult;
+    } catch {
+      return raw;
+    }
+  }
+
+  return raw;
+}
+
+export type PerformSearchResult = {
+  data: SearchResult;
+  hasResults: boolean;
+};
+
+export async function performSearch(query: string): Promise<PerformSearchResult> {
+  const trimmed = query.trim();
+  if (!trimmed) {
+    throw new Error("Search query cannot be empty.");
+  }
+
+  const response = await fetch("/api/search", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json",
+    },
+    body: JSON.stringify({ query: trimmed }),
+  });
+
+  const body = await readResponseBody(response);
+
+  if (!response.ok) {
+    const fallbackMessage = `Search failed (${response.status}).`;
+    if (typeof body === "string" && body.trim()) {
+      throw new Error(body.trim());
+    }
+    if (body && typeof body === "object") {
+      const message =
+        (body as { error?: unknown; message?: unknown }).error ??
+        (body as { error?: unknown; message?: unknown }).message;
+      if (typeof message === "string" && message.trim()) {
+        throw new Error(message.trim());
+      }
+    }
+    throw new Error(fallbackMessage);
+  }
+
+  return {
+    data: body,
+    hasResults: detectHasResults(body),
+  };
+}
+
+export { detectHasResults as hasSearchResults };

--- a/client/pages/SearchResults.tsx
+++ b/client/pages/SearchResults.tsx
@@ -56,7 +56,7 @@ export default function SearchResults() {
     setLoading(true);
     setResult(null);
     try {
-      const { data, hasResults } = await performSearch(query.trim());
+      const { data, hasResults } = await performSearch(query);
       setResult(data);
 
       if (hasResults) {

--- a/client/pages/Shop.tsx
+++ b/client/pages/Shop.tsx
@@ -94,7 +94,7 @@ function PlanCard({ plan, onEmail }: PlanCardProps) {
         }}
       >
         <div className="pointer-events-none absolute inset-x-4 -bottom-5 h-16 translate-y-4 rounded-full bg-amber-500/30 blur-2xl transition-all duration-200 group-hover:translate-y-0.5 dark:bg-amber-400/24" />
-        <Card className="relative h-full rounded-2xl border border-white/10 bg-white/12 px-2 pb-6 pt-4 shadow-lg shadow-brand-500/15 hover:shadow-xl hover:shadow-brand-500/25 backdrop-blur-xl transition-[box-shadow,transform] duration-150 group-hover:-translate-y-0.5 dark:border-white/10 dark:bg-white/8">
+        <Card className="relative h-full rounded-2xl border border-white/10 bg-white/12 px-2 pb-6 pt-4 shadow-md shadow-brand-500/12 hover:shadow-lg hover:shadow-brand-500/18 backdrop-blur-xl transition-[box-shadow,transform] duration-150 group-hover:-translate-y-0.5 dark:border-white/10 dark:bg-white/8">
           <div className="absolute inset-0 opacity-0 transition-opacity duration-200 group-hover:opacity-100">
             <div className="absolute inset-0 rounded-2xl bg-gradient-to-br from-amber-400/25 via-transparent to-brand-500/10" />
           </div>


### PR DESCRIPTION
## Changes Made

### New Search Library
- **Added** `client/lib/search.ts` with centralized search functionality
- **Implemented** `performSearch()` function for handling search API calls
- **Added** `detectHasResults()` utility for determining if search results contain data
- **Included** proper error handling and response parsing for JSON and text responses

### Search Integration
- **Updated** `client/pages/Index.tsx` to use the new `performSearch()` function
- **Updated** `client/pages/SearchResults.tsx` to use the new search library
- **Improved** error handling with better error message extraction
- **Removed** duplicate search logic from both components

### UI Styling Updates
- **Modified** `client/components/home/FeatureGrid.tsx` shadow styling:
  - Changed default shadow from `shadow-md shadow-brand-500/15` to `shadow-sm shadow-brand-500/10`
  - Updated hover shadow from `shadow-lg shadow-brand-500/20` to `shadow-md shadow-brand-500/15`

- **Updated** `client/components/layout/Header.tsx` logo styling:
  - Increased gap between logo and text from `gap-2` to `gap-3`
  - Increased font size from `text-xl` to `text-2xl`
  - Enlarged logo from `h-8 w-8` to `h-10 w-10`
  - Changed logo border radius from `rounded` to `rounded-lg`
  - Added `leading-none` class to text span

- **Adjusted** `client/pages/Shop.tsx` card shadow styling:
  - Reduced default shadow from `shadow-lg shadow-brand-500/15` to `shadow-md shadow-brand-500/12`
  - Updated hover shadow from `shadow-xl shadow-brand-500/25` to `shadow-lg shadow-brand-500/18`

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/7a4844133f7048d1801de545bcfde76c/zenith-garden)

👀 [Preview Link](https://7a4844133f7048d1801de545bcfde76c-zenith-garden.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>7a4844133f7048d1801de545bcfde76c</projectId>-->
<!--<branchName>zenith-garden</branchName>-->